### PR TITLE
Fix interface speed

### DIFF
--- a/src/apps/intel/intel_app.lua
+++ b/src/apps/intel/intel_app.lua
@@ -73,7 +73,7 @@ function Intel82599:new (arg)
       counter.set(self.stats.counters.type, 0x1000) -- Hardware interface
       counter.set(self.stats.counters.dtime, C.get_unix_time())
       counter.set(self.stats.counters.mtu, self.dev.mtu)
-      counter.set(self.stats.counters.speed, 10000000) -- 10 Gbits
+      counter.set(self.stats.counters.speed, 10000000000) -- 10 Gbits
       counter.set(self.stats.counters.status, 2) -- down
       if not conf.vmdq and conf.macaddr then
          counter.set(self.stats.counters.macaddr,

--- a/src/lib/ipc/shmem/iftable_mib.lua
+++ b/src/lib/ipc/shmem/iftable_mib.lua
@@ -30,8 +30,13 @@ function init_snmp (name, counters, directory, interval)
    ifTable:register('ifSpeed', 'Gauge32')
    ifTable:register('ifHighSpeed', 'Gauge32')
    if counters.speed then
-      ifTable:set('ifSpeed', counter.read(counters.speed))
-      ifTable:set('ifHighSpeed', counter.read(counters.speed) / 1000)
+      speed = counters.read(counters.speed)
+      if speed > 1000000000 then
+         ifTable:set('ifSpeed', 4294967295) -- RFC3635 sec. 3.2.8
+      else
+         ifTable:set('ifSpeed', speed)
+      end
+      ifTable:set('ifHighSpeed', speed / 1000000)
    end
    ifTable:register('ifPhysAddress', { type = 'OctetStr', length = 6 })
    if counters.macaddr then


### PR DESCRIPTION
The counters.speed counter should be in bps.  The ifSpeed SNMP
object must obey RFC3635 sec. 3.2.8.
