### PR TITLE
lwaftr: avoid some unsunk allocations of cdata pointers

### DIFF
--- a/src/apps/lwaftr/binding_table.lua
+++ b/src/apps/lwaftr/binding_table.lua
@@ -118,7 +118,6 @@ function BTLookupQueue:get_lookup(n)
       local streamer = self.streamer
       local pkt, b4_ipv6, br_ipv6
       pkt = self.packet_queue[n]
-      self.packet_queue[n] = nil
       if not streamer:is_empty(n) then
          b4_ipv6 = streamer.entries[n].value.b4_ipv6
          br_ipv6 = streamer.entries[n].value.br_address

--- a/src/lib/ctable.lua
+++ b/src/lib/ctable.lua
@@ -463,6 +463,9 @@ function CTable:make_lookup_streamer(width)
       -- more entry.
       stream_entries = self.type(width * (self.max_displacement + 1) + 1)
    }
+   -- Pointer to first entry key (cache to avoid cdata allocation.)
+   local key_offset = 4 -- Skip past uint32_t hash.
+   res.keys = ffi.cast('uint8_t*', res.entries) + key_offset
    -- Give res.pointers sensible default values in case the first lookup
    -- doesn't fill the pointers vector.
    for i = 0, width-1 do res.pointers[i] = self.entries end
@@ -485,13 +488,13 @@ end
 function LookupStreamer:stream()
    local width = self.width
    local entries = self.entries
+   local keys = self.keys
    local pointers = self.pointers
    local stream_entries = self.stream_entries
    local entries_per_lookup = self.entries_per_lookup
    local equal_fn = self.equal_fn
 
-   local key_offset = 4 -- Skip past uint32_t hash.
-   self.multi_hash(ffi.cast('uint8_t*', entries) + key_offset, self.hashes)
+   self.multi_hash(self.keys, self.hashes)
 
    for i=0,width-1 do
       local hash = self.hashes[i]


### PR DESCRIPTION
Through the lens of Studio I found some minor cdata heap allocations in the lwaftr fast path. I was not able to measure the real-world impact of these so I will refrain from calling this an optimization. However, since these cases are fairly typical instances of the cdata pointer heap allocation pitfall / performance cliff I want to document their finding in this PR.

555e4c8 addresses the finding illustrated in the screenshot below. (Construction of a pointer to the entries first key would cause a cdata allocation, allocate that pointer in `new` instead and keep it around.)

The highlighted IR instruction shows the unsunk allocation, and the preceding instruction hints to us that this new cdata object is due us constructing a new pointer by arithmetic (and, presumably, the compiler didn’t find a register to sink it into).

![Screenshot from 2019-10-07 12-12-21@2x](https://user-images.githubusercontent.com/4933566/66307823-c0302600-e905-11e9-9d7f-a4df60bf8e01.png)

ac65ee0 addresses the finding illustrated in the Studio screenshot below. (`BTLookupQueue:get_lookup` would return a pointer stored in a pointer array, but overwrite the pointer in the array with nil prior. This would cause the JIT to produce a cdata heap allocation for the pointer.)

The highlighted IR instructions again shows the unsunk allocation. The preceding IR instruction `pval` indicates this is a value obtained from a parent function. Presumably, since there is no heap memory backing the pointer object, and the compiler couldn’t allocate a register for the pointer, it was forced to allocate new cdata object for the pointer on heap.

![Screenshot from 2019-10-07 12-14-59@2x](https://user-images.githubusercontent.com/4933566/66307845-cfaf6f00-e905-11e9-976a-5ad1ec9ab59b.png)
